### PR TITLE
adding travis' cache for maven and node dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ dist: trusty
 language: java
 jdk:
   - oraclejdk8
+cache:
+  directories:
+  - "$HOME/.m2"
+  - "$HOME/node_modules"
 addons:
   apt:
     packages:


### PR DESCRIPTION
this should avoid lots of log entries for maven downloads and should save bandwidth with the central mirror. Also caches node dependencies (at least the ones of the plugin).